### PR TITLE
chore: npm package setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@hretheum/tokenz",
+  "version": "0.0.1",
+  "description": "Design tokens for hretheum projects",
+  "license": "MIT",
+  "files": ["tokens.json"],
+  "exports": {
+    "./tokens.json": "./tokens.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hretheum/tokenz.git"
+  },
+  "sideEffects": false
+}


### PR DESCRIPTION
Dodaje package.json, README i workflow publikacji na npm. Ustaw w repo sekret NPM_TOKEN, a następnie utwórz release v0.0.1 lub uruchom workflow_dispatch, aby opublikować.